### PR TITLE
Override rounding behaviour

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -132,6 +132,7 @@ function makeIapPostRequest(url, body, idToken, userAgent) {
     method: 'POST',
     json: body,
     resolveWithFullResponse: true,
+    replace_microseconds: false,
   };
 
   return rp.post(options);


### PR DESCRIPTION
In some cases the microseconds can be replaced by the API endpoint and the accuracy of the timestamp goes down to the second. This change attempts to prevent this situation from occurring in the Cloud Function
